### PR TITLE
Bump Xcodeproj to require >= 1.5.9 and < 1.6

### DIFF
--- a/xcodeproj-sort.gemspec
+++ b/xcodeproj-sort.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'xcodeproj-sort'
-  s.version     = '1.0.1'
+  s.version     = '1.0.2"
   s.licenses    = ['MIT']
   s.summary     = "Sort your xcodeproj file in a pre-commit hook."
   s.description = %(
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/noahsark769/xcodeproj-sort-pre-commit-hook'
   s.required_ruby_version = '>= 2.0.0'
   s.executables   = %w(xcodeproj-sort)
-  s.add_runtime_dependency 'xcodeproj', '~> 1.3'
+  s.add_runtime_dependency 'xcodeproj', '~> 1.5.9'
   s.add_runtime_dependency 'claide', '~> 1.0'
   s.metadata    = { "source_code_uri" => "https://github.com/noahsark769/xcodeproj-sort" }
 end

--- a/xcodeproj-sort.gemspec
+++ b/xcodeproj-sort.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'xcodeproj-sort'
-  s.version     = '1.0.2"
+  s.version     = '1.0.2'
   s.licenses    = ['MIT']
   s.summary     = "Sort your xcodeproj file in a pre-commit hook."
   s.description = %(


### PR DESCRIPTION
We're seeing some suspicious behavior in that gem due to functionality that might have changed in 1.5.8. Let's always pin to a version superior to that.