### PR TITLE
Sort multiple projects at once

### DIFF
--- a/bin/xcodeproj-sort
+++ b/bin/xcodeproj-sort
@@ -23,10 +23,8 @@ OptionParser.new do |opts|
   end
 end.parse!
 
+abort "An xcodeproj filename is required." if ARGV.empty?
+
 while filename = ARGV.pop
-  if filename
-    XcodeprojSort.sort(filename.gsub('project.pbxproj', ''), xcodeproj_sort_options)
-  else
-    puts "An xcodeproj filename is required."
-  end
+  XcodeprojSort.sort(filename.gsub('project.pbxproj', ''), xcodeproj_sort_options)
 end

--- a/bin/xcodeproj-sort
+++ b/bin/xcodeproj-sort
@@ -10,7 +10,7 @@ end
 
 xcodeproj_sort_options = nil
 OptionParser.new do |opts|
-  opts.banner = "Usage: xcodeproj-sort [path/to/Project.xcodeproj]"
+  opts.banner = "Usage: xcodeproj-sort [path/to/Project.xcodeproj] ..."
 
   opts.on(
     "-p",
@@ -23,9 +23,10 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-filename = ARGV.pop
-if filename
-  XcodeprojSort.sort(filename.gsub('project.pbxproj', ''), xcodeproj_sort_options)
-else
-  puts "An xcodeproj filename is required."
+while filename = ARGV.pop
+  if filename
+    XcodeprojSort.sort(filename.gsub('project.pbxproj', ''), xcodeproj_sort_options)
+  else
+    puts "An xcodeproj filename is required."
+  end
 end


### PR DESCRIPTION
When used as a pre-commit hook, `xcodeproj-sort` will get passed all `pbxproj`s that have changes in them, but it will only sort the first one on its ARGV. This change causes it to sort all of them by putting the `sort` inside a `while` loop.

While I was here, I changed the changed the failure message to send to `abort` rather than `puts` so the executable exits with nonzero status.