### PR TITLE
Bump to require Xcodeproj >= 1.6.0 < 1.7.0

### DIFF
--- a/xcodeproj-sort.gemspec
+++ b/xcodeproj-sort.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'xcodeproj-sort'
-  s.version     = '1.0.2'
+  s.version     = '1.0.4'
   s.licenses    = ['MIT']
   s.summary     = "Sort your xcodeproj file in a pre-commit hook."
   s.description = %(
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/noahsark769/xcodeproj-sort-pre-commit-hook'
   s.required_ruby_version = '>= 2.0.0'
   s.executables   = %w(xcodeproj-sort)
-  s.add_runtime_dependency 'xcodeproj', '~> 1.5.9'
+  s.add_runtime_dependency 'xcodeproj', '~> 1.6.0'
   s.add_runtime_dependency 'claide', '~> 1.0'
   s.metadata    = { "source_code_uri" => "https://github.com/noahsark769/xcodeproj-sort" }
 end


### PR DESCRIPTION
Fixes errors like https://github.com/CocoaPods/Xcodeproj/issues/608