### PR TITLE
Bump xcodeproj to 1.23.0 to support Xcode 15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 install:
 	gem build xcodeproj-sort.gemspec
-	gem install xcodeproj-sort-1.0.1.gem
+	gem install xcodeproj-sort-1.1.2.gem

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 install:
 	gem build xcodeproj-sort.gemspec
-	gem install xcodeproj-sort-1.1.2.gem
+	gem install xcodeproj-sort-1.1.3.gem

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the following to your `.pre-commit-config.yaml`:
 
 ```
 -   repo: git://github.com/noahsark769/xcodeproj-sort-pre-commit-hook
-    sha: v1.1.1
+    rev: v1.1.2
     hooks:
     - id: xcodeproj-sort
       args: [--groups-position=above]

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # xcodeproj-sort-pre-commit-hook
+
 A pre-commit hook that sorts your xcodeproj file.
 
 <img src="https://i.imgur.com/knSvFpV.png" height="700">
 
 ## What is it?
+
 This repo provides a ready to use [pre-commit](https://pre-commit.com/) hook for automatically sorting your Xcode project. The hook looks for files ending in .pbxproj that have been modified and sorts their project group hierarchy automatically using the [Xcodeproj](https://github.com/CocoaPods/Xcodeproj/) gem. The effect is that the sort leaves your project file modified if it's not sorted, so that pre-commit won't allow the unsorted file to go through.
 
 ## Usage
+
 If you haven't set up pre-commit, check out [pre-commit's installation docs](https://pre-commit.com/#install) first.
 
 Add the following to your `.pre-commit-config.yaml`:
 
 ```
 -   repo: git://github.com/noahsark769/xcodeproj-sort-pre-commit-hook
-    rev: v1.1.2
+    rev: v1.1.3
     hooks:
     - id: xcodeproj-sort
       args: [--groups-position=above]
@@ -26,13 +29,16 @@ pre-commit install
 ```
 
 ### Options
+
 Use the `--groups-position` option to specify the position of groups in the sort:
+
 - `above`: Positions groups above objects in the sort
 - `below`: Positions groups below objects in the sort
 
 The default is to interleave groups and objects in the sort.
 
 ### Running manually
+
 The code runs in a rubygem which is built by `pre-commit`. To run a sort manually outside of `pre-commit`, install the gem locally:
 
 ```
@@ -46,9 +52,11 @@ xcodeproj-sort MyProject.xcodeproj/project.pbxproj
 ```
 
 ## Contributing
+
 I use this in the development of [Trestle](https://itunes.apple.com/us/app/trestle-the-new-sudoku/id1300230302?mt=8) and [CIFilter.io](https://itunes.apple.com/us/app/cifilter-io/id1457458557?mt=8), but your mileage might vary. If you notice a bug or have a feature request, please open a github issue or submit a pull request. It's best to open issues first so that work isn't duplicated.
 
 Also, feel free to reach out [on Twitter](https://twitter.com/noahsark769) if you have any questions.
 
 ## Development
+
 After closing the repo, you can run `make install` to build the gem and install locally, after which `xcodeproj-sort` should be in your path.

--- a/xcodeproj-sort.gemspec
+++ b/xcodeproj-sort.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'xcodeproj-sort'
-  s.version     = '1.1.2'
+  s.version     = '1.1.3'
   s.licenses    = ['MIT']
   s.summary     = "Sort your xcodeproj file in a pre-commit hook."
   s.description = %(
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/noahsark769/xcodeproj-sort-pre-commit-hook'
   s.required_ruby_version = '>= 2.0.0'
   s.executables   = %w(xcodeproj-sort)
-  s.add_runtime_dependency 'xcodeproj', '~> 1.22.0'
+  s.add_runtime_dependency 'xcodeproj', '~> 1.23.0'
   s.add_runtime_dependency 'claide', '~> 1.0'
   s.metadata    = { "source_code_uri" => "https://github.com/noahsark769/xcodeproj-sort" }
 end

--- a/xcodeproj-sort.gemspec
+++ b/xcodeproj-sort.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'xcodeproj-sort'
-  s.version     = '1.1.1'
+  s.version     = '1.1.2'
   s.licenses    = ['MIT']
   s.summary     = "Sort your xcodeproj file in a pre-commit hook."
   s.description = %(
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/noahsark769/xcodeproj-sort-pre-commit-hook'
   s.required_ruby_version = '>= 2.0.0'
   s.executables   = %w(xcodeproj-sort)
-  s.add_runtime_dependency 'xcodeproj', '~> 1.21.0'
+  s.add_runtime_dependency 'xcodeproj', '~> 1.22.0'
   s.add_runtime_dependency 'claide', '~> 1.0'
   s.metadata    = { "source_code_uri" => "https://github.com/noahsark769/xcodeproj-sort" }
 end


### PR DESCRIPTION
This PR supersedes https://github.com/noahsark769/xcodeproj-sort-pre-commit-hook/pull/9 by @kevnm67 to make this pre commit hook work with Xcode 15.