### PR TITLE
Bump xcodeproj to 1.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the following to your `.pre-commit-config.yaml`:
 
 ```
 -   repo: git://github.com/noahsark769/xcodeproj-sort-pre-commit-hook
-    sha: v1.1.1
+    sha: v1.1.2
     hooks:
     - id: xcodeproj-sort
       args: [--groups-position=above]

--- a/xcodeproj-sort.gemspec
+++ b/xcodeproj-sort.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'xcodeproj-sort'
-  s.version     = '1.1.1'
+  s.version     = '1.1.2'
   s.licenses    = ['MIT']
   s.summary     = "Sort your xcodeproj file in a pre-commit hook."
   s.description = %(
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/noahsark769/xcodeproj-sort-pre-commit-hook'
   s.required_ruby_version = '>= 2.0.0'
   s.executables   = %w(xcodeproj-sort)
-  s.add_runtime_dependency 'xcodeproj', '~> 1.21.0'
+  s.add_runtime_dependency 'xcodeproj', '~> 1.27.0'
   s.add_runtime_dependency 'claide', '~> 1.0'
   s.metadata    = { "source_code_uri" => "https://github.com/noahsark769/xcodeproj-sort" }
 end


### PR DESCRIPTION
Just a simple bump to the latest xcodeproj. I think you'll need to add the v1.1.2 tag as well once it is merged.